### PR TITLE
fixed walt variable name inconsistency

### DIFF
--- a/wave.js
+++ b/wave.js
@@ -372,7 +372,7 @@ document.addEventListener("DOMContentLoaded", () => {
     .then(response => response.arrayBuffer())
     .then(bytes => WebAssembly.instantiate(bytes, {}))
     .then(wasm => {
-      slowAssemblyScript = wasm;
+      walt = wasm;
       return fetch('as/build/optimized.wasm');
     })
     .then(response => response.arrayBuffer())


### PR DESCRIPTION
#15 the [instantiated module](https://github.com/jtiscione/webassembly-wave/blob/master/walt/waves.wasm) was set to a different variable, causing `modules.walt` to remain null.